### PR TITLE
feat(source-maps): enable sourcemaps during dev

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -10,6 +10,7 @@ var insert = require('gulp-insert');
 var rename = require('gulp-rename');
 var tools = require('aurelia-tools');
 var del = require('del');
+var sourcemaps = require('gulp-sourcemaps');
 var vinylPaths = require('vinyl-paths');
 
 var jsName = paths.packageName + '.js';
@@ -60,12 +61,21 @@ gulp.task('build-system', function () {
     .pipe(gulp.dest(paths.output + 'system'));
 });
 
+gulp.task('build-dev', function () {
+  return gulp.src(paths.source)
+    .pipe(sourcemaps.init({loadMaps: true}))
+    .pipe(to5(assign({}, compilerOptions, {modules:'system', plugins: []})))
+    .pipe(sourcemaps.write(paths.output + 'dev'))
+    .pipe(gulp.dest(paths.output + 'dev'));
+});
+
 gulp.task('build-dts', function(){
   return gulp.src(paths.output + paths.packageName + '.d.ts')
       .pipe(rename(paths.packageName + '.d.ts'))
       .pipe(gulp.dest(paths.output + 'es6'))
       .pipe(gulp.dest(paths.output + 'commonjs'))
       .pipe(gulp.dest(paths.output + 'amd'))
+      .pipe(gulp.dest(paths.output + 'dev'))
       .pipe(gulp.dest(paths.output + 'system'));
 });
 
@@ -74,6 +84,7 @@ gulp.task('copy-html', function() {
   .pipe(gulp.dest(paths.output + 'es6'))
   .pipe(gulp.dest(paths.output + 'commonjs'))
   .pipe(gulp.dest(paths.output + 'amd'))
+  .pipe(gulp.dest(paths.output + 'dev'))
   .pipe(gulp.dest(paths.output + 'system'));
 
 });
@@ -83,6 +94,7 @@ gulp.task('copy-css', function() {
   .pipe(gulp.dest(paths.output + 'es6'))
   .pipe(gulp.dest(paths.output + 'commonjs'))
   .pipe(gulp.dest(paths.output + 'amd'))
+  .pipe(gulp.dest(paths.output + 'dev'))
   .pipe(gulp.dest(paths.output + 'system'));
 
 });
@@ -92,7 +104,7 @@ gulp.task('build', function(callback) {
   return runSequence(
     'clean',
     'build-index',
-    ['build-es6-temp', 'build-es6', 'build-commonjs', 'build-amd', 'build-system'],
+    ['build-es6-temp', 'build-es6', 'build-commonjs', 'build-amd', 'build-system', 'build-dev'],
     ['copy-html', 'copy-css'],
     'build-dts',
     callback

--- a/build/tasks/serve.js
+++ b/build/tasks/serve.js
@@ -19,8 +19,8 @@ gulp.task('serve', ['build'], function(done) {
   };
 
   // Create a route to the build output directory so we can load the plugin from the subdir
-  
-  options.server.routes['/src/' + paths.packageName] = path.join(paths.output, 'system');
+
+  options.server.routes['/src/' + paths.packageName] = path.join(paths.output, 'dev');
 
   bs.init(options, done);
 });

--- a/build/tasks/watch.js
+++ b/build/tasks/watch.js
@@ -14,7 +14,7 @@ function reportChange(event) {
 gulp.task('watch', ['serve'], function() {
   var bs = browserSync.get('Sample server');
 
-  gulp.watch(paths.source, ['build-system', bs.reload]).on('change', reportChange);
+  gulp.watch(paths.source, ['build-dev', bs.reload]).on('change', reportChange);
   gulp.watch(paths.html, ['copy-html', bs.reload]).on('change', reportChange);
   gulp.watch(paths.sampleStyle, bs.reload).on('change', reportChange);
   gulp.watch(paths.sampleSrc, bs.reload).on('change', reportChange);

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "gulp-eslint": "^1.0.0",
     "gulp-insert": "^0.5.0",
     "gulp-rename": "^1.2.2",
+    "gulp-sourcemaps": "^1.6.0",
     "gulp-typedoc": "^1.2.1",
     "gulp-typedoc-extractor": "0.0.8",
     "isparta": "^4.0.0",


### PR DESCRIPTION
closes https://github.com/aurelia-ui-toolkits/aurelia-materialize-bridge/issues/8

These changes did it for me, but it's your decision on which implementation to use of course