### PR TITLE
Waves on aurelia-cli project

### DIFF
--- a/src/waves/waves.js
+++ b/src/waves/waves.js
@@ -34,7 +34,7 @@ export class MdWaves {
     }
 
     this.attributeManager.addClasses(classes);
-    if (!(typeof window.require === "function" && typeof window.require.specified === "function" && window.require.specified('waves'))) {
+    if (!(typeof window.require === 'function' && typeof window.require.specified === 'function' && window.require.specified('waves'))) {
       Waves.attach(this.element);
     }
   }

--- a/src/waves/waves.js
+++ b/src/waves/waves.js
@@ -34,7 +34,9 @@ export class MdWaves {
     }
 
     this.attributeManager.addClasses(classes);
-    Waves.attach(this.element);
+    if (!(typeof window.require === "function" && typeof window.require.specified === "function" && window.require.specified('waves'))) {
+      Waves.attach(this.element);
+    }
   }
 
   detached() {

--- a/src/waves/waves.js
+++ b/src/waves/waves.js
@@ -34,7 +34,7 @@ export class MdWaves {
     }
 
     this.attributeManager.addClasses(classes);
-    if (!(typeof window.require === 'function' && typeof window.require.specified === 'function' && window.require.specified('waves'))) {
+    if (!(typeof window.requirejs === 'function' && typeof window.requirejs.specified === 'function' && window.requirejs.specified('waves'))) {
       Waves.attach(this.element);
     }
   }


### PR DESCRIPTION
Checking if the bridge is running with global requirejs and only attach waves if not, makes it work with aurelia-cli. Also tested with webpack and jspm.