### PR TITLE
Pagination and visible links

### DIFF
--- a/src/pagination/pagination.html
+++ b/src/pagination/pagination.html
@@ -10,14 +10,14 @@
       <li md-waves click.delegate="setActivePage(p+1)" repeat.for="p of mdPageLinks" class="${ p+1 === mdActivePage ? 'active' : ''}">
         <span if.bind="$first && p > 0">...</span>
         <a>${p+1}</a>
-        <span if.bind="$last && p < mdPages - 1">...</span>
+        <span if.bind="$last && p < pages - 1">...</span>
       </li>
     </template>
     <template if.bind="mdShowPrevNext">
-      <li md-waves click.delegate="setNextPage()" class="${ mdActivePage === mdPages ? 'disabled' : '' }"><a><i class="material-icons">chevron_right</i></a></li>
+      <li md-waves click.delegate="setNextPage()" class="${ mdActivePage == pages ? 'disabled' : '' }"><a><i class="material-icons">chevron_right</i></a></li>
     </template>
     <template if.bind="mdShowFirstLast">
-      <li md-waves click.delegate="setLastPage()" class="${ mdActivePage === mdPages ? 'disabled' : '' }"><a><i class="material-icons">last_page</i></a></li>
+      <li md-waves click.delegate="setLastPage()" class="${ mdActivePage == pages ? 'disabled' : '' }"><a><i class="material-icons">last_page</i></a></li>
     </template>
   </ul>
 </template>

--- a/src/pagination/pagination.js
+++ b/src/pagination/pagination.js
@@ -24,6 +24,8 @@ export class MdPagination {
   @bindable() mdShowPrevNext = true;
   @bindable() mdShowPageLinks = true;
 
+  numberOfLinks = 15;
+
   constructor(element) {
     this.element = element;
   }
@@ -32,7 +34,7 @@ export class MdPagination {
     // attached() throws unhandled exceptions
     this.mdPages = parseInt(this.mdPages, 10);
     // We don't want mdVisiblePageLinks to be greater than mdPages
-    this.mdVisiblePageLinks = Math.min(parseInt(this.mdVisiblePageLinks, 10), this.mdPages);
+    this.numberOfLinks = Math.min(parseInt(this.mdVisiblePageLinks, 10), this.mdPages);
     this.mdShowPrevNext = getBooleanFromAttributeValue(this.mdShowPrevNext);
     this.mdPageLinks = this.generatePageLinks();
   }
@@ -68,18 +70,19 @@ export class MdPagination {
   }
 
   mdPagesChanged() {
+    this.numberOfLinks = Math.min(parseInt(this.mdVisiblePageLinks, 10), this.mdPages);
     this.setActivePage(1);
   }
 
   mdVisiblePageLinksChanged() {
+    this.numberOfLinks = parseInt(this.mdVisiblePageLinks, 10);
     this.mdPageLinks = this.generatePageLinks();
   }
 
   generatePageLinks() {
-    let numberOfLinks = parseInt(this.mdVisiblePageLinks, 10);
-    let midPoint = parseInt((numberOfLinks / 2), 10);
+    let midPoint = parseInt((this.numberOfLinks / 2), 10);
     let start = Math.max(this.mdActivePage - midPoint, 0);
-    let end = Math.min(start + numberOfLinks, this.mdPages);
+    let end = Math.min(start + this.numberOfLinks, this.mdPages);
 
     let list = [];
     for (let i = start; i < end; i++) {

--- a/src/pagination/pagination.js
+++ b/src/pagination/pagination.js
@@ -24,7 +24,9 @@ export class MdPagination {
   @bindable() mdShowPrevNext = true;
   @bindable() mdShowPageLinks = true;
 
+  // local variables to stop Changed events when parsing to int
   numberOfLinks = 15;
+  pages = 5;
 
   constructor(element) {
     this.element = element;
@@ -32,15 +34,16 @@ export class MdPagination {
 
   bind() {
     // attached() throws unhandled exceptions
-    this.mdPages = parseInt(this.mdPages, 10);
+    this.pages = parseInt(this.mdPages, 10);
     // We don't want mdVisiblePageLinks to be greater than mdPages
-    this.numberOfLinks = Math.min(parseInt(this.mdVisiblePageLinks, 10), this.mdPages);
+    this.numberOfLinks = Math.min(parseInt(this.mdVisiblePageLinks, 10), this.pages);
+    this.mdShowFirstLast = getBooleanFromAttributeValue(this.mdShowFirstLast);
     this.mdShowPrevNext = getBooleanFromAttributeValue(this.mdShowPrevNext);
     this.mdPageLinks = this.generatePageLinks();
   }
 
   setActivePage(page) {
-    this.mdActivePage = page;
+    this.mdActivePage = parseInt(page, 10);
     this.mdPageLinks = this.generatePageLinks();
     fireMaterializeEvent(this.element, 'page-changed', this.mdActivePage);
   }
@@ -52,8 +55,8 @@ export class MdPagination {
   }
 
   setLastPage() {
-    if (this.mdActivePage < this.mdPages) {
-      this.setActivePage(this.mdPages);
+    if (this.mdActivePage < this.pages) {
+      this.setActivePage(this.pages);
     }
   }
 
@@ -64,25 +67,28 @@ export class MdPagination {
   }
 
   setNextPage() {
-    if (this.mdActivePage < this.mdPages) {
+    if (this.mdActivePage < this.pages) {
       this.setActivePage(this.mdActivePage + 1);
     }
   }
 
   mdPagesChanged() {
-    this.numberOfLinks = Math.min(parseInt(this.mdVisiblePageLinks, 10), this.mdPages);
+    this.pages = parseInt(this.mdPages, 10);
+    this.numberOfLinks = Math.min(parseInt(this.mdVisiblePageLinks, 10), this.pages);
     this.setActivePage(1);
   }
 
   mdVisiblePageLinksChanged() {
-    this.numberOfLinks = parseInt(this.mdVisiblePageLinks, 10);
+    this.numberOfLinks = Math.min(parseInt(this.mdVisiblePageLinks, 10), this.pages);
     this.mdPageLinks = this.generatePageLinks();
   }
 
   generatePageLinks() {
     let midPoint = parseInt((this.numberOfLinks / 2), 10);
     let start = Math.max(this.mdActivePage - midPoint, 0);
-    let end = Math.min(start + this.numberOfLinks, this.mdPages);
+    // respect visible links
+    if (start + midPoint * 2 > this.pages) start = this.pages - midPoint * 2;
+    let end = Math.min(start + this.numberOfLinks, this.pages);
 
     let list = [];
     for (let i = start; i < end; i++) {


### PR DESCRIPTION
Issues:

1. If you go to [Pagination Options demo](http://aurelia-ui-toolkits.github.io/demo-materialize/#/samples/pagination/options) and change Number of pages to 100 and press show last button, active class is not added to number 100. Also observe that only 8 numbers show in the list.

2. If you set overallPageLinks in that demo-source to 10, and do a gulp watch, visiblePageLinks is set to 10 even after Number of pages is changed to 100. Pager on search form with 0 pages as default will not work without extra code.