### PR TITLE
Remove data-error attribute when removing errors

### DIFF
--- a/src/validation/validationRenderer.js
+++ b/src/validation/validationRenderer.js
@@ -54,6 +54,11 @@ export class MaterializeFormValidationRenderer {
       if (input) {
         input.classList.remove('invalid');
         input.classList.add('valid');
+        
+        var label = element.querySelector('label');
+        if (label) {
+        	label.removeAttribute('data-error');
+        }
       }
       break;
     }

--- a/src/validation/validationRenderer.js
+++ b/src/validation/validationRenderer.js
@@ -54,10 +54,10 @@ export class MaterializeFormValidationRenderer {
       if (input) {
         input.classList.remove('invalid');
         input.classList.add('valid');
-        
-        var label = element.querySelector('label');
+
+        let label = element.querySelector('label');
         if (label) {
-        	label.removeAttribute('data-error');
+          label.removeAttribute('data-error');
         }
       }
       break;


### PR DESCRIPTION
Currently, the attribute is not cleared which later overrides a different error message