### PR TITLE
chore(md-tooltip): remove tooltip before init

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -38,6 +38,7 @@ export class MdTooltip {
   }
 
   initTooltip() {
+    $(this.element).tooltip('remove');
     $(this.element).tooltip({
       delay: parseInt(this.delay, 10),
       html: this.html


### PR DESCRIPTION
Sorry for pull spam. I didn't notice that we had to remove old tooltip before initiate new updated one. #281 

Example: Button with tooltip. Pressing button -> tooltip change in code -> old tooltip is left on screen.