### PR TITLE
fix(typescript): cannot find module errors during compile

### DIFF
--- a/src/exports.js
+++ b/src/exports.js
@@ -1,3 +1,4 @@
+// build-index-remove start
 export * from './autocomplete/autocomplete';
 export * from './badge/badge';
 export * from './box/box';
@@ -57,3 +58,4 @@ export * from './transitions/fadein-image';
 export * from './transitions/staggered-list';
 export * from './validation/validationRenderer';
 export * from './waves/waves';
+// build-index-remove end


### PR DESCRIPTION
In the dark of the night, `build-index-remove` tags in `exports.js`, run deep into the woods and got lost. I found them and followed them safe back.