### PR TITLE
Add validation for textarea and datepicker. Update the sample app.

### DIFF
--- a/sample/src/samples/datepicker/registry.json
+++ b/sample/src/samples/datepicker/registry.json
@@ -12,6 +12,10 @@
     "advanced-options": {
       "route": "advanced-options",
       "files": ["html", "js"]
+    },
+    "validation": {
+      "route": "validation",
+      "files": ["html", "js"]
     }
   }
 }

--- a/sample/src/samples/datepicker/validation.html
+++ b/sample/src/samples/datepicker/validation.html
@@ -1,7 +1,7 @@
 <template>
   <md-card md-title="Basic">
     <div>
-      <input md-datepicker="container: body; value.two-way: date & validate:rules;" type="date" placeholder="pick a date">
+      <input md-datepicker="container: body; value.two-way: date & validate:rules;" md-datepicker.ref="datePicker" type="date" placeholder="pick a date">
     </div>
     <div style="margin-top: 15px;">
       <button md-waves md-button click.delegate="validateModel()">validate</button>
@@ -11,7 +11,7 @@
 
   <md-card md-title="Show or hide error text">
     <div>
-      <input md-datepicker="show-errortext.bind: showErrortext; container: body; value.two-way: date2 & validate:rules;" type="date" placeholder="pick a date">
+      <input md-datepicker="show-errortext.bind: showErrortext; container: body; value.two-way: date2 & validate:rules;" md-datepicker.ref="date2Picker" type="date" placeholder="pick a date">
     </div>
     <div style="margin-top: 15px;">
       <button md-waves md-button click.delegate="validateModel2()">validate</button>
@@ -24,7 +24,7 @@
     <h5 class="error-text">You have errors!</h5>
     <ul style="margin-top: 15px;">
       <li repeat.for="error of controller.errors">
-        <a href="#" click.delegate="error.target.focus()">
+        <a href="#" click.delegate="openErrorTarget(error, $event)">
           ${error.message}
         </a>
       </li>

--- a/sample/src/samples/datepicker/validation.html
+++ b/sample/src/samples/datepicker/validation.html
@@ -1,0 +1,34 @@
+<template>
+  <md-card md-title="Basic">
+    <div>
+      <input md-datepicker="container: body; value.two-way: date & validate:rules;" type="date" placeholder="pick a date">
+    </div>
+    <div style="margin-top: 15px;">
+      <button md-waves md-button click.delegate="validateModel()">validate</button>
+      <button md-waves md-button click.delegate="reset()">reset</button>
+    </div>
+  </md-card>
+
+  <md-card md-title="Show or hide error text">
+    <div>
+      <input md-datepicker="show-errortext.bind: showErrortext; container: body; value.two-way: date2 & validate:rules;" type="date" placeholder="pick a date">
+    </div>
+    <div style="margin-top: 15px;">
+      <button md-waves md-button click.delegate="validateModel2()">validate</button>
+      <button md-waves md-button click.delegate="reset2()">reset</button>
+    </div>
+    <md-switch style="margin-top: 15px;" md-label-on="show" md-label-off="hide" md-checked.bind="showErrortext"></md-switch>
+  </md-card>
+
+  <md-card if.bind="controller.errors.length">
+    <h5 class="error-text">You have errors!</h5>
+    <ul style="margin-top: 15px;">
+      <li repeat.for="error of controller.errors">
+        <a href="#" click.delegate="error.target.focus()">
+          ${error.message}
+        </a>
+      </li>
+    </ul>
+  </md-card>
+
+</template>

--- a/sample/src/samples/datepicker/validation.js
+++ b/sample/src/samples/datepicker/validation.js
@@ -4,8 +4,8 @@ import { MaterializeFormValidationRenderer } from 'aurelia-materialize-bridge';
 
 @inject(NewInstance.of(ValidationController))
 export class Validation {
-  date = '';
-  date2 = '';
+  date = null;
+  date2 = null;
   showErrortext = false;
 
   controller = null;
@@ -26,12 +26,12 @@ export class Validation {
   }
 
   reset() {
-    this.selectedValue = '';
+    this.date = null;
     this.controller.reset({ object: this, propertyName: 'date' });
   }
 
   reset2() {
-    this.selectedValue2 = '';
+    this.date2 = null;
     this.controller.reset({ object: this, propertyName: 'date2' });
   }
 
@@ -41,5 +41,10 @@ export class Validation {
 
   validateModel2() {
     return this.controller.validate({ object: this, propertyName: 'date2' });
+  }
+
+  openErrorTarget(error, $event) {
+    this[`${error.propertyName}Picker`].openDatePicker();
+    $event.preventDefault();
   }
 }

--- a/sample/src/samples/datepicker/validation.js
+++ b/sample/src/samples/datepicker/validation.js
@@ -1,0 +1,45 @@
+import { inject, NewInstance } from 'aurelia-framework';
+import { ValidationController, ValidationRules } from 'aurelia-validation';
+import { MaterializeFormValidationRenderer } from 'aurelia-materialize-bridge';
+
+@inject(NewInstance.of(ValidationController))
+export class Validation {
+  date = '';
+  date2 = '';
+  showErrortext = false;
+
+  controller = null;
+
+  rules = ValidationRules
+    .ensure('date')
+      .displayName('Date')
+      .required()
+    .ensure('date2')
+      .displayName('Show or hide error text date')
+      .required()
+    .on(this)
+    .rules;
+
+  constructor(controller: ValidationController) {
+    this.controller = controller;
+    this.controller.addRenderer(new MaterializeFormValidationRenderer());
+  }
+
+  reset() {
+    this.selectedValue = '';
+    this.controller.reset({ object: this, propertyName: 'date' });
+  }
+
+  reset2() {
+    this.selectedValue2 = '';
+    this.controller.reset({ object: this, propertyName: 'date2' });
+  }
+
+  validateModel() {
+    return this.controller.validate({ object: this, propertyName: 'date' });
+  }
+
+  validateModel2() {
+    return this.controller.validate({ object: this, propertyName: 'date2' });
+  }
+}

--- a/sample/src/samples/input/aurelia-validation.html
+++ b/sample/src/samples/input/aurelia-validation.html
@@ -31,18 +31,6 @@
       md-value.bind="textareaValue & validate:rules"
       md-text-area="true">
     </md-input>
-
-    <select md-select="label: select a value" value.two-way="selectedItem & validate:rules">
-      <option value="" disabled selected>select an item</option>
-      <option value="item1">item 1</option>
-      <option value="item2">item 2</option>
-      <option value="item3">item 3</option>
-      <option value="item4">item 4</option>
-    </select>
-
-    <div>
-      <input md-datepicker="container: body; value.two-way: selectedDate & validate:rules;" type="date" placeholder="pick a date">
-    </div>
   </div>
 
   <div style="margin-top: 15px;">

--- a/sample/src/samples/input/aurelia-validation.html
+++ b/sample/src/samples/input/aurelia-validation.html
@@ -25,6 +25,24 @@
       md-show-errortext="false"
       md-value.bind="noErrorText & validate:rules">
     </md-input>
+
+    <md-input
+      md-label="put some text here"
+      md-value.bind="textareaValue & validate:rules"
+      md-text-area="true">
+    </md-input>
+
+    <select md-select="label: select a value" value.two-way="selectedItem & validate:rules">
+      <option value="" disabled selected>select an item</option>
+      <option value="item1">item 1</option>
+      <option value="item2">item 2</option>
+      <option value="item3">item 3</option>
+      <option value="item4">item 4</option>
+    </select>
+
+    <div>
+      <input md-datepicker="container: body; value.two-way: selectedDate & validate:rules;" type="date" placeholder="pick a date">
+    </div>
   </div>
 
   <div style="margin-top: 15px;">

--- a/sample/src/samples/input/aurelia-validation.js
+++ b/sample/src/samples/input/aurelia-validation.js
@@ -9,9 +9,7 @@ export class AureliaValidation {
   lastName = 'Doe';
   email = '';
   noErrorText = '';
-  textarea = '';
-  selectedItem = '';
-  selectedDate = '';
+  textareaValue = '';
 
   controller = null;
 
@@ -26,11 +24,7 @@ export class AureliaValidation {
       .email()
     .ensure('noErrorText')
       .required()
-    .ensure('selectedItem').displayName('Item')
-      .required()
     .ensure('textareaValue').displayName('Some text')
-      .required()
-    .ensure('selectedDate').displayName('Date')
       .required()
     .rules;
 

--- a/sample/src/samples/input/aurelia-validation.js
+++ b/sample/src/samples/input/aurelia-validation.js
@@ -9,6 +9,9 @@ export class AureliaValidation {
   lastName = 'Doe';
   email = '';
   noErrorText = '';
+  textarea = '';
+  selectedItem = '';
+  selectedDate = '';
 
   controller = null;
 
@@ -22,6 +25,12 @@ export class AureliaValidation {
         .withMessage('We need your email')
       .email()
     .ensure('noErrorText')
+      .required()
+    .ensure('selectedItem').displayName('Item')
+      .required()
+    .ensure('textareaValue').displayName('Some text')
+      .required()
+    .ensure('selectedDate').displayName('Date')
       .required()
     .rules;
 

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -5,6 +5,7 @@ import {inject} from 'aurelia-dependency-injection';
 import {getLogger} from 'aurelia-logging';
 import {getBooleanFromAttributeValue} from '../common/attributes';
 import {DatePickerDefaultParser} from './datepicker-default-parser';
+import {fireEvent} from '../common/events';
 
 @inject(Element, TaskQueue, DatePickerDefaultParser)
 @customAttribute('md-datepicker')
@@ -146,6 +147,7 @@ export class MdDatePicker {
   onClose() {
     let selected = this.picker.get('select');
     this.value = selected ? selected.obj : null;
+    fireEvent(this.element, 'blur');
   }
 
   onCalendarIconClick(event) {

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -16,6 +16,7 @@ export class MdDatePicker {
   @bindable({defaultBindingMode: bindingMode.oneTime}) selectMonths = true;
   @bindable({defaultBindingMode: bindingMode.oneTime}) selectYears = 15;
   @bindable({defaultBindingMode: bindingMode.oneTime}) options = {};
+  @bindable() showErrortext = true;
 
   constructor(element, taskQueue, defaultParser) {
     this.element = element;
@@ -106,6 +107,7 @@ export class MdDatePicker {
     }
 
     this.movePickerCloserToSrc();
+    this.setErrorTextAttribute();
   }
 
   parseDate(value) {
@@ -170,5 +172,14 @@ export class MdDatePicker {
     // });
   }
 
+  showErrortextChanged() {
+    this.setErrorTextAttribute();
+  }
 
+  setErrorTextAttribute() {
+    const element = this.element;
+    if (!element) return;
+    this.log.debug('showErrortextChanged: ' + this.showErrortext);
+    element.setAttribute('data-show-errortext', getBooleanFromAttributeValue(this.showErrortext));
+  }
 }

--- a/src/validation/validationRenderer.js
+++ b/src/validation/validationRenderer.js
@@ -55,7 +55,10 @@ export class MaterializeFormValidationRenderer {
       if (element.hasAttribute('md-datepicker')) {
         element.classList.remove('valid');
         element.classList.add('invalid');
-        this.addMessage(element.parentNode, error);
+        if (!(element.hasAttribute('data-show-errortext') &&
+            element.getAttribute('data-show-errortext') === 'false')) {
+          this.addMessage(element.parentNode, error);
+        }
       }
       break;
     }
@@ -92,8 +95,10 @@ export class MaterializeFormValidationRenderer {
     case 'INPUT' : {
       if (element.hasAttribute('md-datepicker')) {
         this.removeMessage(element.parentNode, error);
-        element.classList.remove('invalid');
-        element.classList.add('valid');
+        if (element && element.parentNode.querySelectorAll('.' + this.className).length === 0) {
+          element.classList.remove('invalid');
+          element.classList.add('valid');
+        }
       }
       break;
     }

--- a/src/validation/validationRenderer.js
+++ b/src/validation/validationRenderer.js
@@ -20,7 +20,7 @@ export class MaterializeFormValidationRenderer {
     switch (element.tagName) {
     case 'MD-INPUT': {
       let label = element.querySelector('label');
-      let input = element.querySelector('input');
+      let input = element.querySelector('input') || element.querySelector('textarea');
       if (label) {
         label.removeAttribute('data-error');
       }
@@ -51,6 +51,14 @@ export class MaterializeFormValidationRenderer {
       }
       break;
     }
+    case 'INPUT' : {
+      if (element.hasAttribute('md-datepicker')) {
+        element.classList.remove('valid');
+        element.classList.add('invalid');
+        this.addMessage(element.parentNode, error);
+      }
+      break;
+    }
     default: break;
     }
   }
@@ -60,7 +68,7 @@ export class MaterializeFormValidationRenderer {
     case 'MD-INPUT': {
       this.removeMessage(element, error);
 
-      let input = element.querySelector('input');
+      let input = element.querySelector('input') || element.querySelector('textarea');
       if (input && element.querySelectorAll('.' + this.className).length === 0) {
         input.classList.remove('invalid');
         input.classList.add('valid');
@@ -78,6 +86,14 @@ export class MaterializeFormValidationRenderer {
       if (input && selectWrapper.querySelectorAll('.' + this.className).length === 0) {
         input.classList.remove('invalid');
         input.classList.add('valid');
+      }
+      break;
+    }
+    case 'INPUT' : {
+      if (element.hasAttribute('md-datepicker')) {
+        this.removeMessage(element.parentNode, error);
+        element.classList.remove('invalid');
+        element.classList.add('valid');
       }
       break;
     }


### PR DESCRIPTION
I have made some modification for displaying the error on `textarea` and `datepicker` elements with `aurelia-validation`, which I need in my app. I have also update the sample app with some example for the `select`, `textarea` and `datepicker` elements.

The only problem I get is that the datepicker error doesn't add/remove when changing the value, but only if we click again on the input field or if we trigger the validation manually. But I think that is a problem on the way the value is changed on a datepicker because it doesn't trigger the `render` function of the `ValidationRenderer` when changing the value.