### PR TITLE
fix(md-progress): set md-pixel-size on attached

### DIFF
--- a/src/progress/progress.js
+++ b/src/progress/progress.js
@@ -25,23 +25,24 @@ export class MdProgress {
   //   console.log('mdValueChanged, newValue:', JSON.stringify(newValue), 'oldValue:', JSON.stringify(oldValue));
   // }
 
+  bind() {
+    // This disables property changed callbacks for any bindable properties during initialization
+    // Prevents mdPixelSize getting cleared by the mdSizeChanged event during binding
+  }
+
+  attached() {
+    this.mdPixelSizeChanged(this.mdPixelSize);
+  }
+
   mdSizeChanged(newValue) {
     this.mdPixelSize = null;
-    if (this.wrapper) {
-      this.wrapper.style.height = '';
-      this.wrapper.style.width = '';
-    }
   }
 
   mdPixelSizeChanged(newValue) {
-    if (isNaN(newValue)) {
-      this.mdPixelSize = null;
-    } else {
-      this.mdSize = '';
-      if (this.wrapper) {
-        this.wrapper.style.height = `${newValue}px`;
-        this.wrapper.style.width = `${newValue}px`;
-      }
+    if (this.wrapper) {
+      newValue = (newValue === null || newValue === '' || isNaN(newValue)) ? '' : `${newValue}px`;
+      this.wrapper.style.height = newValue;
+      this.wrapper.style.width = newValue;
     }
   }
 }


### PR DESCRIPTION
md-pixel-size was not working if set to a static value or set before the attached event.  It was only working as used in the sample but didn't work as it would typically be used.

Also, let mdSize remain set when mdPixelSize is set.  mdPixelSize overrides mdSize due to inline styles having higher priority.