### PR TITLE
refactor(validation) remove the md-select error in all cases

### DIFF
--- a/sample/src/samples/select/validation.html
+++ b/sample/src/samples/select/validation.html
@@ -10,6 +10,7 @@
     <div style="margin-top: 15px;">
       <button md-waves md-button click.delegate="validateModel()">validate</button>
       <button md-waves md-button click.delegate="reset()">reset</button>
+      <button md-waves md-button click.delegate="setItem3()">Set to item 3</button>
     </div>
   </md-card>
 

--- a/sample/src/samples/select/validation.js
+++ b/sample/src/samples/select/validation.js
@@ -42,4 +42,8 @@ export class Validation {
   validateModel2() {
     return this.controller.validate({ object: this, propertyName: 'selectedValue2' });
   }
+
+  setItem3() {
+    this.selectedValue = 'item3';
+  }
 }

--- a/src/validation/validationRenderer.js
+++ b/src/validation/validationRenderer.js
@@ -83,7 +83,12 @@ export class MaterializeFormValidationRenderer {
       if (!selectWrapper) {
         return;
       }
-      this.removeMessage(selectWrapper, error);
+
+      if ($(selectWrapper.parentElement).children().hasClass('md-input-validation') ) {
+        this.removeMessage(selectWrapper.parentElement, error);
+      } else {
+        this.removeMessage(selectWrapper, error);
+      }
 
       let input = selectWrapper.querySelector('input');
       if (input && selectWrapper.querySelectorAll('.' + this.className).length === 0) {


### PR DESCRIPTION
I have added an example on the validation of a select because when an error is displayed under a select and then we change the value dynamically, the error was not removed, even after a reset, and cause some weird displaying of the label.

I have made two commits, one to add the example in the `sample` solution and one that fix the bug in the `validationRenderer`