### PR TITLE
Change range to one-way instead of one-time

### DIFF
--- a/src/range/range.html
+++ b/src/range/range.html
@@ -1,6 +1,6 @@
 <template>
   <require from="./range.css"></require>
   <p class="range-field">
-    <input type="range" min.one-time="mdMin" max.one-time="mdMax" step.one-time="mdStep" value.bind="mdValue" ref="input" />
+    <input type="range" min.one-way="mdMin" max.one-way="mdMax" step.one-way="mdStep" value.bind="mdValue" ref="input" />
   </p>
 </template>


### PR DESCRIPTION
I think this would be better, because there are defintely use cases where one wants to change the range min, max etc. values.

However, i'm not familiar with your "goales", so it might be that you want to reject this and encourage people to use the range input directly without AMB, if they have such a use case.