### PR TITLE
Add collapsible open/close events

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "typescript.check.workspaceVersion": false
+    "typescript.check.workspaceVersion": false,
+    "jshint.enable": false
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -11,7 +11,11 @@
 		"node_modules",
 		"bower_components",
 		"jspm_packages",
-		"tmp",
-		"temp"
+    "tmp",
+    "temp",
+		"build",
+		"devbuild",
+    "dist",
+    "samples"
 	]
 }

--- a/sample/src/shared/components.json
+++ b/sample/src/shared/components.json
@@ -131,7 +131,8 @@
           "gist": "11ad8a83b750f39bd0e9c6159d6861b4"
         },
         "accordion": "6fd3210550aef8ef490242e45c01e669",
-        "popout": "8ca123a0299c7bb7be32fb181d6d1644"
+        "popout": "8ca123a0299c7bb7be32fb181d6d1644",
+        "open-close-callbacks": "24b0ae0562e766878eabbf3ced10d0df"
       }
     },
     "Dialogs (toast/tooltip)": {


### PR DESCRIPTION
Main work here is surfacing the open/close events from the Materialize collapsible component in friendly ways for the Aurelia developer. The developer can hook these events in one of two ways:

 1. Using the `.call` expression in the attribute to directly bind a function call on their view model via the new `onOpen` and `onClose` properties (note: `on-open` and `on-close` in attribute syntax!).
 2. Via the `EventAggregator` infrastructure where two new events are published in the form of: `aurelia-md-bridge:collapsible:[open|close]`. I would especially like feedback on whether or not you guys want the framework to be publishing via `EventAggregator` and, if so, if you "like" the naming scheme I've chosen.

*NOTE:* this also adds a new sample for the Collapsible component from [this gist](https://gist.github.com/drub0y/24b0ae0562e766878eabbf3ced10d0df) to demonstrate how both approaches could be used to the caller. If you think these should be broken up into two different samples I can certainly do that.

Ancillary work included here just updates some project level settings to make the project more friendly to work with (at least from VSCode). Details in commit message for 669e8db should be pretty straightfwd so I won't repeat them here.