### PR TITLE
Update datepicker.js

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -64,7 +64,7 @@ export class MdDatePicker {
       Object.assign(options, this.options);
       //merge callback methods if there is a hook in the advanced options
       if (this.options.onClose) {
-        options.onClose = function() {
+        options.onClose = () => {
           this.options.onClose();
           $(document.activeElement).blur();
         };


### PR DESCRIPTION
fix(datepicker): Datepicker `onClose` option issue

Setting option `onClose` will cause: "Uncaught TypeError: Cannot read property 'onClose' of undefined"

Closes https://github.com/aurelia-ui-toolkits/aurelia-materialize-bridge/issues/407