### PR TITLE
fix(validation): use correct validation container for SELECT

### DIFF
--- a/src/select/select.js
+++ b/src/select/select.js
@@ -55,7 +55,12 @@ export class MdSelect {
     this.observeVisibleDropdownContent(false);
     this.observeOptions(false);
     this.dropdownMutationObserver = null;
-    $(this.element).parent().children(".md-input-validation").remove();
+    if (this.label) {
+      $(this.element).parent().parent().children(".md-input-validation").remove();
+    }
+    else {
+      $(this.element).parent().children(".md-input-validation").remove();
+    }
     $(this.element).parent().children(`ul#select-options-${$(this.element).data('select-id')}`).remove();
     $(this.element).material_select('destroy');
     this.subscriptions.forEach(sub => sub.dispose());

--- a/src/validation/validationRenderer.js
+++ b/src/validation/validationRenderer.js
@@ -37,8 +37,8 @@ export class MaterializeFormValidationRenderer {
         const selectWrapper = element.closest('.select-wrapper');
         if (selectWrapper) {
           input = selectWrapper.querySelector('input');
+          validationContainer = selectWrapper.closest(".input-field") || selectWrapper;
         }
-        validationContainer = selectWrapper;
         break;
       }
       case 'INPUT': {
@@ -89,7 +89,7 @@ export class MaterializeFormValidationRenderer {
         result.target = input;
         if (!(input.hasAttribute('data-show-errortext') &&
             input.getAttribute('data-show-errortext') === 'false')) {
-          this.addMessage(selectWrapper, result);
+          this.addMessage(selectWrapper.closest(".input-field") || selectWrapper, result);
         }
       }
       break;


### PR DESCRIPTION
When a SELECT has a label it's best to add validation DIVs to the `.input-field` rather than to the `.select-wrapper`.
This ensures that validation DIVs do not appear before the LABEL element (it might happen because SELECT sometimes calls `createMaterialSelect` which ruins elements' order).