### PR TITLE
fix(colors): color for `.btn-floating.error:hover`

### DIFF
--- a/src/colors/md-colors.html
+++ b/src/colors/md-colors.html
@@ -104,7 +104,7 @@
   .btn.error, .btn-flat.error, .btn-large.error {
     transition: .2s ease-out;
   }
-  .btn.error:hover, .btn-flat.error:hover, .btn-large.error:hover, .btn-floating:hover {
+  .btn.error:hover, .btn-flat.error:hover, .btn-large.error:hover, .btn-floating.error:hover {
     background-color: ${mdErrorColor | lighten:1};
     transition: .2s ease-out;
   }


### PR DESCRIPTION
The style was overriding the previous declaration