### PR TITLE
Removed peerDependencies completely

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,9 +105,6 @@
     "vinyl-paths": "^1.0.0",
     "yargs": "^2.1.1"
   },
-  "peerDependencies": {
-    "materialize-css": "^0.98.0"
-  },
   "aurelia": {
     "usedBy": [],
     "documentation": {


### PR DESCRIPTION
I removed the peerDependencies completely, because it's still optional to use materialize-css or github:Dogfalo/materialize.

That fixes https://github.com/aurelia-ui-toolkits/aurelia-materialize-bridge/issues/438