### PR TITLE
fix(md-tabs): reset click event in refresh method to allow dynamically added tabs

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -66,9 +66,11 @@ export class MdTabs {
   refresh() {
     this.taskQueue.queueTask(() => {
       let hrefs = [];
-      $('li a', this.element).each(function(i, tab) {
+      $('li a', this.element).each((i, tab) => {
         $(tab).parent().addClass('tab');
         hrefs.push($(tab).attr('href'));
+        tab.removeEventListener('click', this.fireTabSelectedEvent);
+        tab.addEventListener('click', this.fireTabSelectedEvent);
       });
       $(hrefs).each((i, tab) => {
         if (this.selectedTab.index != i) {


### PR DESCRIPTION
to fire the custom tabSelected event