### PR TITLE
fix(select): restore validation state after refresh

### DIFF
--- a/src/select/select.js
+++ b/src/select/select.js
@@ -178,10 +178,20 @@ export class MdSelect {
     }
     this.observeVisibleDropdownContent(false);
     this.observeOptions(false);
+    let input = $(this.element).siblings("input");
+    let isValid = input.hasClass("valid");
+    let isInvalid = input.hasClass("invalid");    
     if (destroy) {
       $(this.element).material_select('destroy');
     }
     $(this.element).material_select();
+    input = $(this.element).siblings("input");
+    if (isValid) {
+      input.addClass("valid");
+    }
+    if (isInvalid) {
+      input.addClass("invalid");
+    }    
     this.toggleControl(this.disabled);
     this.observeVisibleDropdownContent(true);
     this.observeOptions(true);


### PR DESCRIPTION
Plus, readonly did not work because of the missing code