### PR TITLE
fix(colors): color for `btn-floating.error:focus`

### DIFF
--- a/src/colors/md-colors.html
+++ b/src/colors/md-colors.html
@@ -108,7 +108,7 @@
     background-color: ${mdErrorColor | lighten:1};
     transition: .2s ease-out;
   }
-  .btn.error:focus, .btn-flat.error:focus, .btn-large.error:focus, .btn-floating:focus {
+  .btn.error:focus, .btn-flat.error:focus, .btn-large.error:focus, .btn-floating.error:focus {
     background-color: ${mdErrorColor | lighten:0.5};
     transition: .2s ease-out;
   }


### PR DESCRIPTION
Fix a typo that was overriding the normal .btn-floating:focus style