### PR TITLE
feat(input): add maxlength attribute for input and textarea

### DIFF
--- a/src/input/input.html
+++ b/src/input/input.html
@@ -10,6 +10,7 @@
       type.bind="mdType"
       min.bind="mdMin"
       max.bind="mdMax"
+      maxlength.bind="mdMaxlength"
       name.bind="mdName"
       step.bind="mdStep"
       value.bind="mdValue"
@@ -26,6 +27,7 @@
       class="materialize-textarea"
       readonly.bind="mdReadonly"
       disabled.bind="mdDisabled"
+      maxlength.bind="mdMaxlength"
       blur.trigger="blur()"
       focus.trigger="focus()"
     ></textarea>

--- a/src/input/input.js
+++ b/src/input/input.js
@@ -51,6 +51,10 @@ export class MdInput {
     defaultBindingMode: bindingMode.oneTime
   }) mdName = '';
 
+  @bindable({
+    defaultBindingMode: bindingMode.oneTime
+  }) mdMaxlength = 524288;
+
   _suspendUpdate = false;
 
   constructor(element, taskQueue, updateService) {


### PR DESCRIPTION
Basic html input attribute maxlength was missing from the binding