### PR TITLE
onAutocomplete firing a change event for non-v1

### DIFF
--- a/src/autocomplete/autocomplete.ts
+++ b/src/autocomplete/autocomplete.ts
@@ -39,7 +39,8 @@ export class MdAutoComplete {
 		$(this.input).autocomplete({
 			data: this.values,
 			minLength: this.minLength,
-			limit: this.limit
+			limit: this.limit,
+			onAutocomplete: () => fireEvent(this.input, "change")
 		});
 		$(this.input).siblings(".autocomplete-content").on("click", () => {
 			fireEvent(this.input, "change");


### PR DESCRIPTION
I'm firing a change event for onAutocomplete to fix the problem that I was having with using the keyboard to select something from the dropdown and the change event not firing. 
Fixes #514 

This is just for non-v1, and probably would be good to add it here as well if the PR is accepted: https://github.com/aurelia-ui-toolkits/aurelia-materialize-bridge/blob/v1/src/autocomplete/autocomplete.ts#L44 
