### PR TITLE
Add lookup tweaks

### DIFF
--- a/src/lookup/lookup.ts
+++ b/src/lookup/lookup.ts
@@ -3,20 +3,7 @@ import { LookupState } from "./lookup-state";
 import { ILookupOptionsFunctionParameter } from "./i-lookup-options-function-parameter";
 import { DiscardablePromise, discard } from "../common/discardable-promise";
 
-export enum BlurAction {
-	/**
-	 * Do nothing
-	 */
-	Nothing 			= 0,
-	/**
-	 * If filter matches no options, clear filter and value
-	 */
-	ClearOnNoMatch 		= 1 << 0,
-	/**
-	 * If there is one remaining option, set this option as the value
-	 */
-	SetOnMatch 			= 1 << 1
-}
+export type BlurAction = "Nothing" | "ClearOnNoMatch" | "SetOnMatch" | "Both";
 
 @au.customElement("md-lookup")
 @au.autoinject
@@ -41,7 +28,7 @@ export class MdLookup {
 	logger: au.Logger;
 
 	@au.bindable({ defaultBindingMode: au.bindingMode.oneTime })
-	blurAction: BlurAction = BlurAction.Nothing;
+	blurAction: BlurAction = "Nothing";
 
 	@au.bindable({ defaultBindingMode: au.bindingMode.twoWay })
 	filter: string;
@@ -204,19 +191,19 @@ export class MdLookup {
 	}
 
 	blur() {
-		if ((this.blurAction & BlurAction.SetOnMatch) && this.options && this.options.length === 1) {
-			this.setValue(this.options[0])
-			this.setFilter(this.getDisplayValue(this.options[0]))
-		} else if ((this.blurAction & BlurAction.ClearOnNoMatch) && this.optionsContainsText(this.filter)) {
-			this.setValue(undefined)
-			this.setFilter(undefined)
+		if ((["SetOnMatch", "Both"].includes(this.blurAction)) && this.options && this.options.length === 1) {
+			this.setValue(this.options[0]);
+			this.setFilter(this.getDisplayValue(this.options[0]));
+		} else if (["ClearOnNoMatch", "Both"].includes(this.blurAction) && this.optionsContainsText(this.filter)) {
+			this.setValue(undefined);
+			this.setFilter(undefined);
 		}
 		this.close();
 		au.fireEvent(this.element, "blur");
 	}
 
 	optionsContainsText(txt: string) {
-		return !this.options || !this.options.some(opt => this.getDisplayValue(opt) == txt)
+		return !this.options || !this.options.some(opt => this.getDisplayValue(opt) === txt);
 	}
 
 	focus() {


### PR DESCRIPTION
- Add open() on element focus.
- Add onBlur behaviour options: Enables setting the underlying value if the user blurs the element and the filter is a match with a single option. Also enables the clearing of the filter and value if the current filter matches no options.

Monkey tested.